### PR TITLE
test(comment): add accessible end-to-end ownership coverage

### DIFF
--- a/app/backend/src/modules/comments/toggle-spam.routes.test.ts
+++ b/app/backend/src/modules/comments/toggle-spam.routes.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Variables } from "@/factory.js";
+import * as toggleSpamModule from "./services/toggle-spam.js";
+import { createTestCommentApp } from "./test-utils.js";
+
+vi.mock(import("@/env.js"), () => ({
+  env: { FRONTEND_URL: "http://localhost:3000" } as any,
+}));
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("comment moderation route", () => {
+  it("passes an authenticated admin to the spam policy", async () => {
+    const auth = {
+      user: {
+        id: "admin-1",
+        name: "E2E Admin",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      session: {},
+    } as Variables["auth"];
+    const toggle = vi
+      .spyOn(toggleSpamModule, "toggleCommentSpam")
+      .mockResolvedValueOnce({ code: 200, data: { success: true } });
+
+    const response = await createTestCommentApp(auth).request("/toggle-spam", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: 42, isSpam: true }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(toggle).toHaveBeenCalledWith(
+      42,
+      true,
+      expect.objectContaining({
+        user: expect.objectContaining({ id: "admin-1", role: "admin" }),
+      }),
+    );
+  });
+});

--- a/app/comment-e2e/.gitignore
+++ b/app/comment-e2e/.gitignore
@@ -1,0 +1,3 @@
+.tmp/
+playwright-report/
+test-results/

--- a/app/comment-e2e/index.html
+++ b/app/comment-e2e/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comment E2E Fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Comment E2E Fixture</h1>
+      <div id="root"></div>
+    </main>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/comment-e2e/package.json
+++ b/app/comment-e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/comment-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:fixture": "turbo run build --filter=@repo/comment",
+    "check-types": "tsc --noEmit",
+    "host": "vite --host localhost --port 3100",
+    "test:e2e": "pnpm build:fixture && node scripts/reset-database.mjs && playwright test",
+    "test:e2e:ui": "pnpm build:fixture && node scripts/reset-database.mjs && playwright test --ui"
+  },
+  "dependencies": {
+    "@repo/comment": "workspace:*",
+    "@tanstack/react-query": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "catalog:",
+    "vite": "^8.1.0"
+  }
+}

--- a/app/comment-e2e/playwright.config.ts
+++ b/app/comment-e2e/playwright.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(fileURLToPath(import.meta.url));
+const backendDir = resolve(packageDir, "../backend");
+const databasePath = resolve(packageDir, ".tmp/comment-e2e.db");
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  outputDir: "./test-results",
+  reporter: [["list"], ["html", { outputFolder: "playwright-report" }]],
+  use: {
+    baseURL: "http://localhost:3100",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: "pnpm exec tsx src/index.ts",
+      cwd: backendDir,
+      env: {
+        ...process.env,
+        FRONTEND_URL: "http://localhost:3100",
+        BACKEND_URL: "http://localhost:3101/api/",
+        UNSUBSCRIBE_SECRET: "comment-e2e-unsubscribe-secret",
+        BETTER_AUTH_SECRET: "comment-e2e-auth-secret-at-least-32-characters",
+        DATABASE_URL: `file:${databasePath}`,
+        GITHUB_CLIENT_ID: "comment-e2e-github-client",
+        GITHUB_CLIENT_SECRET: "comment-e2e-github-secret",
+        EMAIL_NOTIFICATION_ENABLED: "false",
+        EMAIL_FROM: "comment-e2e@example.com",
+        SMTP_HOST: "localhost",
+        SMTP_PORT: "1025",
+        SMTP_SECURE: "false",
+        SMTP_USER: "comment-e2e",
+        SMTP_PASS: "comment-e2e",
+        LOG_LEVEL: "warn",
+      },
+      url: "http://localhost:3101/api/health",
+      reuseExistingServer: false,
+      timeout: 30_000,
+    },
+    {
+      command: "pnpm host",
+      cwd: packageDir,
+      url: "http://localhost:3100",
+      reuseExistingServer: false,
+      timeout: 30_000,
+    },
+  ],
+});

--- a/app/comment-e2e/scripts/reset-database.mjs
+++ b/app/comment-e2e/scripts/reset-database.mjs
@@ -1,0 +1,8 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const databaseDir = resolve(packageDir, ".tmp");
+mkdirSync(databaseDir, { recursive: true });
+rmSync(resolve(databaseDir, "comment-e2e.db"), { force: true });

--- a/app/comment-e2e/src/main.tsx
+++ b/app/comment-e2e/src/main.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import CommentYuline from "@repo/comment";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <CommentYuline
+        serverURL="http://localhost:3101/api/"
+        pathname="/e2e/comments"
+      />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/app/comment-e2e/src/main.tsx
+++ b/app/comment-e2e/src/main.tsx
@@ -6,13 +6,15 @@ import CommentYuline from "@repo/comment";
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
+const fixturePath =
+  new URLSearchParams(window.location.search).get("path") ?? "/e2e/comments";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <CommentYuline
         serverURL="http://localhost:3101/api/"
-        pathname="/e2e/comments"
+        pathname={fixturePath}
       />
     </QueryClientProvider>
   </StrictMode>,

--- a/app/comment-e2e/tests/comment-fixture.ts
+++ b/app/comment-e2e/tests/comment-fixture.ts
@@ -1,0 +1,48 @@
+import { expect, type Page } from "@playwright/test";
+
+type AddedCommentResponse = {
+  data: { id: number };
+};
+
+export async function openCommentFixture(page: Page, path: string) {
+  await page.goto(`/?path=${encodeURIComponent(path)}`);
+}
+
+export async function postGuestComment(
+  page: Page,
+  options: { path: string; content: string },
+) {
+  await openCommentFixture(page, options.path);
+  await page.getByRole("button", { name: "以游客身份留言" }).click();
+  await page.getByRole("textbox", { name: "昵称" }).fill("E2E Guest");
+  await page.getByRole("textbox", { name: "邮箱" }).fill("guest@example.com");
+  await page.getByRole("textbox", { name: "评论内容" }).fill(options.content);
+
+  const added = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname === "/api/v1/comments/add",
+  );
+  await page.getByRole("button", { name: "发送评论" }).click();
+  const response = await added;
+  expect(response.ok()).toBe(true);
+  await expect(page.getByText(options.content)).toBeVisible();
+
+  return ((await response.json()) as AddedCommentResponse).data.id;
+}
+
+export async function addThumbsUpReaction(page: Page, commentId: number) {
+  const added = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname ===
+        `/api/v1/comments/reaction/${commentId}/add`,
+  );
+  await page.getByRole("button", { name: "添加表情" }).click();
+  await page.getByRole("button", { name: "thumbs up" }).click();
+  const response = await added;
+  expect(response.ok()).toBe(true);
+  await expect(
+    page.getByRole("button", { name: /👍.*1/, pressed: true }),
+  ).toBeVisible();
+}

--- a/app/comment-e2e/tests/comment-ownership.spec.ts
+++ b/app/comment-e2e/tests/comment-ownership.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from "@playwright/test";
+import { openCommentFixture, postGuestComment } from "./comment-fixture";
+import { signUpViewer } from "./identity-fixture";
+
+async function postSignedInComment(
+  page: Page,
+  options: { path: string; content: string; userName: string },
+) {
+  await openCommentFixture(page, options.path);
+  await signUpViewer(page, options.userName);
+  await page.getByRole("textbox", { name: "评论内容" }).fill(options.content);
+  const added = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname === "/api/v1/comments/add",
+  );
+  await page.getByRole("button", { name: "发送评论" }).click();
+  const response = await added;
+  expect(response.ok()).toBe(true);
+  return ((await response.json()) as { data: { id: number } }).data.id;
+}
+
+test("signed-in author edits and deletes a comment through accessible actions", async ({
+  page,
+}) => {
+  const original = "Signed-in comment to edit";
+  await postSignedInComment(page, {
+    path: "/e2e/signed-in-comment-ownership",
+    content: original,
+    userName: "Comment Owner",
+  });
+
+  const article = page.getByRole("article", { name: new RegExp(original) });
+  await article.getByRole("button", { name: "更多评论操作" }).click();
+  await page.getByRole("menuitem", { name: "编辑" }).click();
+  await article
+    .getByRole("textbox", { name: "评论内容" })
+    .fill("Edited signed-in comment");
+  await article.getByRole("button", { name: "保存评论" }).click();
+  await expect(page.getByText("Edited signed-in comment")).toBeVisible();
+
+  const editedArticle = page.getByRole("article", {
+    name: /Edited signed-in comment/,
+  });
+  await editedArticle.getByRole("button", { name: "更多评论操作" }).click();
+  await page.getByRole("menuitem", { name: "删除" }).click();
+  await expect(page.getByText("Edited signed-in comment")).toHaveCount(0);
+});
+
+test("guest replies through controls scoped to the parent comment", async ({
+  page,
+}) => {
+  const parentContent = "Guest parent comment";
+  await postGuestComment(page, {
+    path: "/e2e/guest-reply",
+    content: parentContent,
+  });
+
+  const parent = page.getByRole("article", {
+    name: new RegExp(parentContent),
+  });
+  await parent.getByRole("button", { name: "回复" }).click();
+  await parent
+    .getByRole("textbox", { name: "评论内容" })
+    .fill("Guest child reply");
+  await parent.getByRole("button", { name: "发送评论" }).click();
+  await expect(page.getByText("Guest child reply")).toBeVisible();
+});
+
+test("another viewer cannot see controls or mutate a signed-in comment", async ({
+  browser,
+  page: ownerPage,
+}) => {
+  const path = "/e2e/comment-unauthorized";
+  const content = "User-owned comment";
+  const commentId = await postSignedInComment(ownerPage, {
+    path,
+    content,
+    userName: "Protected Owner",
+  });
+
+  const otherContext = await browser.newContext();
+  const otherPage = await otherContext.newPage();
+  await openCommentFixture(otherPage, path);
+  const article = otherPage.getByRole("article", {
+    name: new RegExp(content),
+  });
+  await expect(
+    article.getByRole("button", { name: "更多评论操作" }),
+  ).toHaveCount(0);
+
+  const update = await otherPage.request.post(
+    "http://localhost:3101/api/v1/comments/update",
+    { data: { id: commentId, rawContent: "Attacker edit" } },
+  );
+  expect(update.status()).toBe(401);
+  const deletion = await otherPage.request.post(
+    "http://localhost:3101/api/v1/comments/delete",
+    { data: { id: commentId } },
+  );
+  expect(deletion.status()).toBe(401);
+
+  await ownerPage.reload();
+  await expect(ownerPage.getByText(content)).toBeVisible();
+  await otherContext.close();
+});

--- a/app/comment-e2e/tests/guest-comment-refactor.contract.spec.ts
+++ b/app/comment-e2e/tests/guest-comment-refactor.contract.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import { postGuestComment } from "./comment-fixture";
+import { signUpViewer } from "./identity-fixture";
+
+test.describe("guest comment ownership refactor contract", () => {
+  test.skip(
+    process.env.GUEST_IDENTITY_REFACTOR !== "1",
+    "Activated as red tests on the dedicated refactor branch",
+  );
+
+  test("same-browser guest edits and deletes their comment", async ({
+    page,
+  }) => {
+    const original = "Guest-owned editable comment";
+    await postGuestComment(page, {
+      path: "/e2e/refactor-guest-comment-owner",
+      content: original,
+    });
+
+    const article = page.getByRole("article", { name: new RegExp(original) });
+    await article.getByRole("button", { name: "更多评论操作" }).click();
+    await page.getByRole("menuitem", { name: "编辑" }).click();
+    await article
+      .getByRole("textbox", { name: "评论内容" })
+      .fill("Guest-edited comment");
+    await article.getByRole("button", { name: "保存评论" }).click();
+    await expect(page.getByText("Guest-edited comment")).toBeVisible();
+
+    const edited = page.getByRole("article", { name: /Guest-edited comment/ });
+    await edited.getByRole("button", { name: "更多评论操作" }).click();
+    await page.getByRole("menuitem", { name: "删除" }).click();
+    await expect(page.getByText("Guest-edited comment")).toHaveCount(0);
+  });
+
+  test("signing in preserves controls for the browser's earlier guest comment", async ({
+    page,
+  }) => {
+    const content = "Guest comment retained after sign in";
+    await postGuestComment(page, {
+      path: "/e2e/refactor-guest-comment-sign-in",
+      content,
+    });
+    await signUpViewer(page, "Later Signed-in Guest");
+
+    const article = page.getByRole("article", { name: new RegExp(content) });
+    await expect(
+      article.getByRole("button", { name: "更多评论操作" }),
+    ).toBeVisible();
+  });
+
+  test("another browser cannot modify a guest-owned comment", async ({
+    browser,
+    page: ownerPage,
+  }) => {
+    const content = "Cross-browser protected guest comment";
+    const commentId = await postGuestComment(ownerPage, {
+      path: "/e2e/refactor-guest-comment-other-browser",
+      content,
+    });
+
+    const otherContext = await browser.newContext();
+    const otherPage = await otherContext.newPage();
+    await otherPage.goto(
+      "/?path=%2Fe2e%2Frefactor-guest-comment-other-browser",
+    );
+    const article = otherPage.getByRole("article", {
+      name: new RegExp(content),
+    });
+    await expect(
+      article.getByRole("button", { name: "更多评论操作" }),
+    ).toHaveCount(0);
+
+    const update = await otherPage.request.post(
+      "http://localhost:3101/api/v1/comments/update",
+      { data: { id: commentId, rawContent: "Cross-browser attack" } },
+    );
+    expect([401, 403, 404]).toContain(update.status());
+    const deletion = await otherPage.request.post(
+      "http://localhost:3101/api/v1/comments/delete",
+      { data: { id: commentId } },
+    );
+    expect([401, 403, 404]).toContain(deletion.status());
+    await otherContext.close();
+  });
+});

--- a/app/comment-e2e/tests/guest-comment.spec.ts
+++ b/app/comment-e2e/tests/guest-comment.spec.ts
@@ -1,15 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { postGuestComment } from "./comment-fixture";
 
 test("guest posts a comment through accessible controls", async ({ page }) => {
-  await page.goto("/");
-
-  await page.getByRole("button", { name: "以游客身份留言" }).click();
-  await page.getByRole("textbox", { name: "昵称" }).fill("E2E Guest");
-  await page.getByRole("textbox", { name: "邮箱" }).fill("guest@example.com");
-  await page
-    .getByRole("textbox", { name: "评论内容" })
-    .fill("Accessible end-to-end comment");
-  await page.getByRole("button", { name: "发送评论" }).click();
-
+  await postGuestComment(page, {
+    path: "/e2e/guest-comment",
+    content: "Accessible end-to-end comment",
+  });
   await expect(page.getByText("Accessible end-to-end comment")).toBeVisible();
 });

--- a/app/comment-e2e/tests/guest-comment.spec.ts
+++ b/app/comment-e2e/tests/guest-comment.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("guest posts a comment through accessible controls", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "以游客身份留言" }).click();
+  await page.getByRole("textbox", { name: "昵称" }).fill("E2E Guest");
+  await page.getByRole("textbox", { name: "邮箱" }).fill("guest@example.com");
+  await page
+    .getByRole("textbox", { name: "评论内容" })
+    .fill("Accessible end-to-end comment");
+  await page.getByRole("button", { name: "发送评论" }).click();
+
+  await expect(page.getByText("Accessible end-to-end comment")).toBeVisible();
+});

--- a/app/comment-e2e/tests/guest-identity-refactor.contract.spec.ts
+++ b/app/comment-e2e/tests/guest-identity-refactor.contract.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import { addThumbsUpReaction, postGuestComment } from "./comment-fixture";
+import {
+  clearGuestCookie,
+  clearGuestProjection,
+  signUpViewer,
+} from "./identity-fixture";
+
+test.describe("Guest Identity refactor contract", () => {
+  test.skip(
+    process.env.GUEST_IDENTITY_REFACTOR !== "1",
+    "Activated as red tests on the dedicated refactor branch",
+  );
+
+  test("sign in retains guest reaction ownership and canonicalizes a later add", async ({
+    page,
+  }) => {
+    const commentId = await postGuestComment(page, {
+      path: "/e2e/refactor-sign-in-inheritance",
+      content: "Retain this guest reaction after sign in",
+    });
+    await addThumbsUpReaction(page, commentId);
+
+    await signUpViewer(page, "Inherited Guest User");
+    const inheritedReaction = page.getByRole("button", {
+      name: /👍.*1/,
+      pressed: true,
+    });
+    await expect(inheritedReaction).toBeVisible();
+
+    const userAdd = await page.request.post(
+      `http://localhost:3101/api/v1/comments/reaction/${commentId}/add`,
+      { data: { emoji: "👍" } },
+    );
+    expect(userAdd.ok()).toBe(true);
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: /👍.*1/, pressed: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /👍.*1/, pressed: true }).click();
+    await expect(page.getByRole("button", { name: /👍/ })).toHaveCount(0);
+  });
+
+  test("a server-confirmed cookie silently restores a missing projection", async ({
+    page,
+  }) => {
+    const commentId = await postGuestComment(page, {
+      path: "/e2e/refactor-restore-projection",
+      content: "Restore my guest projection",
+    });
+    await addThumbsUpReaction(page, commentId);
+    await clearGuestProjection(page);
+    await page.reload();
+
+    await expect(
+      page.getByRole("button", { name: /👍.*1/, pressed: true }),
+    ).toBeVisible();
+    expect(
+      await page.evaluate(() => localStorage.getItem("commentAnonymousKey")),
+    ).toBeTruthy();
+  });
+
+  test("a server-confirmed missing cookie silently clears a stale projection", async ({
+    context,
+    page,
+  }) => {
+    const commentId = await postGuestComment(page, {
+      path: "/e2e/refactor-clear-stale-projection",
+      content: "Do not retain stale guest ownership",
+    });
+    await addThumbsUpReaction(page, commentId);
+    await clearGuestCookie(context);
+    await page.reload();
+
+    await expect(
+      page.getByRole("button", { name: /👍.*1/, pressed: false }),
+    ).toBeVisible();
+    expect(
+      await page.evaluate(() => localStorage.getItem("commentAnonymousKey")),
+    ).toBeNull();
+  });
+
+  test("missing identity confirmation fails closed without claiming guest resources", async ({
+    page,
+  }) => {
+    const commentId = await postGuestComment(page, {
+      path: "/e2e/refactor-fail-closed",
+      content: "Fail closed when identity metadata is missing",
+    });
+    await addThumbsUpReaction(page, commentId);
+
+    await page.route(/\/api\/v1\/comments\/?$/, async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const headers = response.headers();
+      delete headers["x-anonymous-key"];
+      delete headers["x-guest-identity"];
+      delete headers["x-guest-identity-state"];
+      await route.fulfill({ response, headers });
+    });
+    await page.reload();
+
+    await expect(
+      page.getByRole("button", { name: /👍.*1/, pressed: false }),
+    ).toBeVisible();
+  });
+});

--- a/app/comment-e2e/tests/guest-reaction.spec.ts
+++ b/app/comment-e2e/tests/guest-reaction.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import {
+  addThumbsUpReaction,
+  openCommentFixture,
+  postGuestComment,
+} from "./comment-fixture";
+
+const anonymousCookie = "anon_key";
+const anonymousProjection = "commentAnonymousKey";
+
+test("first guest reaction creates and reuses a browser identity", async ({
+  context,
+  page,
+}) => {
+  const path = "/e2e/guest-reaction-first";
+  const commentId = await postGuestComment(page, {
+    path,
+    content: "React to this as a first-time guest",
+  });
+
+  expect(
+    (await context.cookies()).find((cookie) => cookie.name === anonymousCookie),
+  ).toBeUndefined();
+  expect(
+    await page.evaluate(
+      (key) => localStorage.getItem(key),
+      anonymousProjection,
+    ),
+  ).toBeNull();
+
+  await addThumbsUpReaction(page, commentId);
+
+  const cookie = (await context.cookies()).find(
+    (candidate) => candidate.name === anonymousCookie,
+  );
+  expect(cookie?.httpOnly).toBe(true);
+  const projectedKey = await page.evaluate(
+    (key) => localStorage.getItem(key),
+    anonymousProjection,
+  );
+  expect(projectedKey).toBeTruthy();
+
+  for (const emoji of ["👍", "👍🏻"]) {
+    const response = await page.request.post(
+      `http://localhost:3101/api/v1/comments/reaction/${commentId}/add`,
+      { data: { emoji } },
+    );
+    expect(response.ok()).toBe(true);
+  }
+
+  await openCommentFixture(page, path);
+  const selectedReaction = page.getByRole("button", {
+    name: /👍.*1/,
+    pressed: true,
+  });
+  await expect(selectedReaction).toBeVisible();
+
+  await selectedReaction.click();
+  await expect(page.getByRole("button", { name: /👍/ })).toHaveCount(0);
+});
+
+test("a copied public key cannot remove another browser's reaction", async ({
+  browser,
+  page: victimPage,
+}) => {
+  const path = "/e2e/guest-reaction-forgery";
+  const commentId = await postGuestComment(victimPage, {
+    path,
+    content: "Victim guest reaction",
+  });
+  await addThumbsUpReaction(victimPage, commentId);
+  const victimProjectedKey = await victimPage.evaluate(
+    (key) => localStorage.getItem(key),
+    anonymousProjection,
+  );
+  expect(victimProjectedKey).toBeTruthy();
+
+  const attackerContext = await browser.newContext();
+  const attackerPage = await attackerContext.newPage();
+  await openCommentFixture(attackerPage, path);
+  await attackerPage.evaluate(
+    ({ key, value }) => localStorage.setItem(key, value!),
+    { key: anonymousProjection, value: victimProjectedKey },
+  );
+  await attackerPage.reload();
+
+  const forgedSelectedReaction = attackerPage.getByRole("button", {
+    name: /👍.*1/,
+    pressed: true,
+  });
+  await expect(forgedSelectedReaction).toBeVisible();
+  const removeAttempt = attackerPage.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname ===
+        `/api/v1/comments/reaction/${commentId}/remove`,
+  );
+  await forgedSelectedReaction.click();
+  expect((await removeAttempt).status()).toBe(204);
+  await expect(forgedSelectedReaction).toBeVisible();
+
+  await attackerPage.reload();
+  await expect(
+    attackerPage.getByRole("button", { name: /👍.*1/, pressed: true }),
+  ).toBeVisible();
+
+  const forgedRequest = await attackerPage.request.post(
+    `http://localhost:3101/api/v1/comments/reaction/${commentId}/remove`,
+    {
+      data: { emoji: "👍", anonymousKey: victimProjectedKey },
+      headers: { "x-anonymous-key": victimProjectedKey! },
+    },
+  );
+  expect(forgedRequest.status()).toBe(204);
+
+  await victimPage.reload();
+  await expect(
+    victimPage.getByRole("button", { name: /👍.*1/, pressed: true }),
+  ).toBeVisible();
+  await attackerContext.close();
+});

--- a/app/comment-e2e/tests/identity-fixture.ts
+++ b/app/comment-e2e/tests/identity-fixture.ts
@@ -1,0 +1,33 @@
+import { expect, type BrowserContext, type Page } from "@playwright/test";
+
+const sessionCacheKey = "yfi-session";
+
+export async function signUpViewer(page: Page, name: string) {
+  const email = `${name.toLowerCase().replaceAll(" ", "-")}-${Date.now()}@example.com`;
+  const response = await page.request.post(
+    "http://localhost:3101/api/v1/auth/sign-up/email",
+    {
+      data: { name, email, password: "comment-e2e-password" },
+      headers: { Origin: "http://localhost:3100" },
+    },
+  );
+  expect(response.ok()).toBe(true);
+
+  await page.evaluate((key) => localStorage.removeItem(key), sessionCacheKey);
+  await page.reload();
+  await expect(page.getByRole("img", { name })).toBeVisible();
+}
+
+export async function signOutViewer(page: Page, name: string) {
+  await page.getByRole("img", { name }).hover();
+  await page.getByRole("button", { name: "退出登录" }).click();
+  await expect(page.getByRole("textbox", { name: "评论内容" })).toBeVisible();
+}
+
+export async function clearGuestCookie(context: BrowserContext) {
+  await context.clearCookies({ name: "anon_key" });
+}
+
+export async function clearGuestProjection(page: Page) {
+  await page.evaluate(() => localStorage.removeItem("commentAnonymousKey"));
+}

--- a/app/comment-e2e/tests/identity-transition.spec.ts
+++ b/app/comment-e2e/tests/identity-transition.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { addThumbsUpReaction, postGuestComment } from "./comment-fixture";
+import { signOutViewer, signUpViewer } from "./identity-fixture";
+
+test("current reaction identities remain separate across sign in and sign out", async ({
+  page,
+}) => {
+  const path = "/e2e/current-identity-transition";
+  const commentId = await postGuestComment(page, {
+    path,
+    content: "Current identity transition",
+  });
+  await addThumbsUpReaction(page, commentId);
+
+  const userName = "Transition User";
+  await signUpViewer(page, userName);
+  await expect(
+    page.getByRole("button", { name: /👍.*1/, pressed: false }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /👍.*1/, pressed: false }).click();
+  await expect(
+    page.getByRole("button", { name: /👍.*2/, pressed: true }),
+  ).toBeVisible();
+
+  await signOutViewer(page, userName);
+  await expect(
+    page.getByRole("button", { name: /👍.*2/, pressed: true }),
+  ).toBeVisible();
+});

--- a/app/comment-e2e/tsconfig.json
+++ b/app/comment-e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": [
+    "playwright.config.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts"
+  ]
+}

--- a/lib/comment/src/comment/box/edit-comment.tsx
+++ b/lib/comment/src/comment/box/edit-comment.tsx
@@ -54,6 +54,7 @@ export function CommentBoxEdit({
         submit={handleSubmit}
         onCancel={onCancel}
         mutationKey={mutationKey}
+        submitLabel="保存评论"
       />
     </CommentBoxIdContext>
   );

--- a/lib/comment/src/comment/box/input-box.tsx
+++ b/lib/comment/src/comment/box/input-box.tsx
@@ -1,5 +1,6 @@
 import { type MutationStatus, useMutationState } from "@tanstack/react-query";
 import { useAtom, type WritableAtom } from "jotai";
+import { useId } from "react";
 import MingcuteCloseLine from "~icons/mingcute/close-line";
 import MingcuteLoadingLine from "~icons/mingcute/loading-line";
 import MingcuteSendPlaneLine from "~icons/mingcute/send-plane-line";
@@ -33,6 +34,7 @@ export function InputBox({
   onCancel,
 }: InputBoxProps) {
   const [content, setContent] = useAtom(contentAtom);
+  const textareaId = useId();
 
   const status =
     useMutationState({
@@ -53,7 +55,11 @@ export function InputBox({
         </div>
       )}
 
+      <label htmlFor={textareaId} className="sr-only">
+        评论内容
+      </label>
       <textarea
+        id={textareaId}
         value={content}
         onChange={(e) => setContent(e.target.value)}
         onKeyDown={(e) => {
@@ -105,6 +111,7 @@ function InputBoxFooter({
         </div>
         {isAnonymousAtom && <AnonymousCheckbox atom={isAnonymousAtom} />}
         <button
+          aria-label="发送评论"
           onClick={() => submit()}
           className="flex items-center gap-0.5 hover:scale-105 active:scale-95 disabled:opacity-50"
           disabled={status === "pending" || !content.trim()}

--- a/lib/comment/src/comment/box/input-box.tsx
+++ b/lib/comment/src/comment/box/input-box.tsx
@@ -13,6 +13,7 @@ interface InputBoxProps {
   placeholder?: string;
   mutationKey: readonly unknown[];
   onCancel?: () => void;
+  submitLabel?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ export function InputBox({
   placeholder,
   mutationKey,
   onCancel,
+  submitLabel = "发送评论",
 }: InputBoxProps) {
   const [content, setContent] = useAtom(contentAtom);
   const textareaId = useId();
@@ -47,6 +49,7 @@ export function InputBox({
       {onCancel && (
         <div className="absolute -top-3 -right-2">
           <button
+            aria-label="取消编辑"
             onClick={onCancel}
             className="rounded-full bg-zinc-200 p-1 hover:scale-105 active:scale-95 dark:bg-zinc-800"
           >
@@ -80,6 +83,7 @@ export function InputBox({
         submit={submit}
         isAnonymousAtom={isAnonymousAtom}
         status={status}
+        submitLabel={submitLabel}
       />
     </div>
   );
@@ -90,6 +94,7 @@ interface InputBoxFooterProps {
   submit: () => void;
   isAnonymousAtom?: WritableAtom<boolean, [boolean], void>;
   status: MutationStatus;
+  submitLabel: string;
 }
 
 function InputBoxFooter({
@@ -97,6 +102,7 @@ function InputBoxFooter({
   isAnonymousAtom,
   submit,
   status,
+  submitLabel,
 }: InputBoxFooterProps) {
   return (
     <div className="flex items-center justify-between gap-2 px-1 text-sm text-comment">
@@ -111,7 +117,7 @@ function InputBoxFooter({
         </div>
         {isAnonymousAtom && <AnonymousCheckbox atom={isAnonymousAtom} />}
         <button
-          aria-label="发送评论"
+          aria-label={submitLabel}
           onClick={() => submit()}
           className="flex items-center gap-0.5 hover:scale-105 active:scale-95 disabled:opacity-50"
           disabled={status === "pending" || !content.trim()}

--- a/lib/comment/src/comment/box/user-box.tsx
+++ b/lib/comment/src/comment/box/user-box.tsx
@@ -53,6 +53,7 @@ export function UserBox({ children, session }: UserBoxProps) {
         />
         <div className="absolute -top-1 -right-1 z-10 hidden size-4 rounded-md bg-zinc-500/50 p-0.5 group-hover:block">
           <button
+            aria-label="退出登录"
             onClick={() => void handleSignOut()}
             className="flex size-full items-center justify-center"
           >

--- a/lib/comment/src/comment/box/visitor-box.tsx
+++ b/lib/comment/src/comment/box/visitor-box.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { motion } from "motion/react";
-import type { PropsWithChildren } from "react";
+import { type PropsWithChildren, useId } from "react";
 import { toast } from "sonner";
 import GitHubIcon from "~icons/mingcute/github-line";
 import MailSendLineIcon from "~icons/mingcute/mail-send-line";
@@ -21,6 +21,8 @@ export function VisitorBox({ children }: PropsWithChildren) {
   const [asVisitor, setAsVisitor] = useAtom(persistentAsVisitorAtom);
   const [visitorName, setVisitorName] = useAtom(persistentNameAtom);
   const [visitorEmail, setVisitorEmail] = useAtom(persistentEmailAtom);
+  const nameId = useId();
+  const emailId = useId();
 
   if (!asVisitor) {
     return <VisitorBoxLogin setAsVisitor={() => setAsVisitor(true)} />;
@@ -29,15 +31,23 @@ export function VisitorBox({ children }: PropsWithChildren) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex w-full justify-between gap-2">
+        <label htmlFor={nameId} className="sr-only">
+          昵称
+        </label>
         <input
+          id={nameId}
           type="text"
           placeholder="昵称*"
           className="flex-1 rounded-md border border-container p-1 focus:ring focus:ring-primary focus:outline-none"
           value={visitorName}
           onChange={(e) => setVisitorName(e.target.value)}
         />
+        <label htmlFor={emailId} className="sr-only">
+          邮箱
+        </label>
         <input
-          type="text"
+          id={emailId}
+          type="email"
           placeholder="邮箱*"
           className="flex-1 rounded-md border border-container p-1 focus:ring focus:ring-primary focus:outline-none"
           value={visitorEmail}

--- a/lib/comment/src/comment/list/comment-dropdown.tsx
+++ b/lib/comment/src/comment/list/comment-dropdown.tsx
@@ -37,12 +37,12 @@ export function CommentDropdown({ comment, onEdit }: CommentDropdownProps) {
 
   // Only show dropdown for owners or admins
   if (!isMine && !isAdmin) {
-    return <div></div>;
+    return null;
   }
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger aria-label="更多评论操作">
         <MoreIcon />
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/lib/comment/src/comment/list/comment-item.tsx
+++ b/lib/comment/src/comment/list/comment-item.tsx
@@ -31,7 +31,10 @@ export function CommentItem({ comment, replyToName }: CommentItemProps) {
     session && comment.userId && comment.userId === session.user.id;
 
   return (
-    <div id={`comment-${comment.id}`}>
+    <article
+      id={`comment-${comment.id}`}
+      aria-label={`${comment.displayName}：${comment.rawContent}`}
+    >
       <div className="flex items-start gap-3 border-zinc-100 py-2 last:border-b-0">
         {/* Avatar */}
         <div className="shrink-0">
@@ -150,6 +153,6 @@ export function CommentItem({ comment, replyToName }: CommentItemProps) {
           )}
         </AnimatePresence>
       </AutoResizeHeight>
-    </div>
+    </article>
   );
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "dev:b": "turbo watch dev --filter=@repo/backend",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test:e2e:comment": "pnpm --dir app/comment-e2e test:e2e",
     "prepare": "husky"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "husky": "^9.1.7",
     "prettier": "^3.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier@3.8.5)
@@ -216,7 +219,7 @@ importers:
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.5)(typescript@6.0.3)
       '@astrojs/mdx':
         specifier: ^7.0.0
-        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^6.0.0
         version: 6.0.0(@types/node@26.0.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -258,7 +261,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       astro:
         specifier: ^7.0.3
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
       astro-seo:
         specifier: ^1.1.0
         version: 1.1.0(prettier-plugin-astro@0.14.1)(prettier@3.8.5)(typescript@6.0.3)
@@ -383,6 +386,40 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  app/comment-e2e:
+    dependencies:
+      '@repo/comment':
+        specifier: workspace:*
+        version: link:../../lib/comment
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.101.1(react@19.2.7)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: 26.0.1
+        version: 26.0.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.0
+        version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
 
   lib/api:
     dependencies:
@@ -2316,6 +2353,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
@@ -2459,6 +2502,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -5166,6 +5214,11 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6386,6 +6439,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -7856,7 +7919,12 @@ snapshots:
   '@astrojs/compiler-binding-linux-x64-musl@0.2.3':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.2.3':
+  '@astrojs/compiler-binding-wasm32-wasi@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@astrojs/compiler-binding-win32-arm64-msvc@0.2.3':
@@ -7865,7 +7933,7 @@ snapshots:
   '@astrojs/compiler-binding-win32-x64-msvc@0.2.3':
     optional: true
 
-  '@astrojs/compiler-binding@0.2.3':
+  '@astrojs/compiler-binding@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@astrojs/compiler-binding-darwin-arm64': 0.2.3
       '@astrojs/compiler-binding-darwin-x64': 0.2.3
@@ -7873,13 +7941,19 @@ snapshots:
       '@astrojs/compiler-binding-linux-arm64-musl': 0.2.3
       '@astrojs/compiler-binding-linux-x64-gnu': 0.2.3
       '@astrojs/compiler-binding-linux-x64-musl': 0.2.3
-      '@astrojs/compiler-binding-wasm32-wasi': 0.2.3
+      '@astrojs/compiler-binding-wasm32-wasi': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/compiler-binding-win32-arm64-msvc': 0.2.3
       '@astrojs/compiler-binding-win32-x64-msvc': 0.2.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.2.3':
+  '@astrojs/compiler-rs@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@astrojs/compiler-binding': 0.2.3
+      '@astrojs/compiler-binding': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   '@astrojs/compiler@2.13.1': {}
 
@@ -7951,13 +8025,13 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.3
 
-  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -8345,6 +8419,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@bruits/satteri-win32-arm64-msvc@0.9.3':
@@ -9270,6 +9345,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@neon-rs/load@0.0.4': {}
 
   '@noble/ciphers@2.2.0': {}
@@ -9367,6 +9449,10 @@ snapshots:
   '@pinojs/redact@0.4.0': {}
 
   '@pkgr/core@0.3.6': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -10183,6 +10269,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.3':
@@ -11077,9 +11164,9 @@ snapshots:
       - prettier-plugin-astro
       - typescript
 
-  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0):
+  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(@upstash/redis@1.35.3)(jiti@2.7.0)(rollup@4.53.3)(terser@5.43.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
-      '@astrojs/compiler-rs': 0.2.3
+      '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-satteri': 0.3.2
       '@astrojs/telemetry': 3.3.2
@@ -11147,6 +11234,8 @@ snapshots:
       - '@azure/storage-blob'
       - '@capacitor/preferences'
       - '@deno/kv'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@netlify/blobs'
       - '@planetscale/database'
       - '@types/node'
@@ -12080,6 +12169,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -13611,6 +13703,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@6.0.10:
     dependencies:


### PR DESCRIPTION
## What changed

- add an isolated Playwright harness for the real comment widget and Hono backend
- exercise guest comments, reactions, sign-in transitions, ownership controls, and unauthorized requests through accessible selectors
- add missing labels and accessible names to comment controls
- record the Guest Identity user stories, implementation tickets, and disposable prototype used to define the later refactor

## Why

This establishes a green browser-level baseline before changing ownership behavior. The tests cover the public UI → API → database path and retain traces/screenshots on failure.

## Impact

This PR does not change comment/reaction authorization, persistence, or identity behavior. Production component changes are limited to accessibility semantics required by the role/label-based tests.

## Validation

- comment E2E baseline is green on commit `d611b96`
- backend moderation route regression coverage is included
- later behavior changes remain isolated to the stacked Guest Identity PR
