### PR TITLE
fix(blog): bound GitHub content fetching

### DIFF
--- a/app/blog-astro/package.json
+++ b/app/blog-astro/package.json
@@ -39,6 +39,7 @@
     "lucide-react": "^1.21.0",
     "motion": "catalog:",
     "ofetch": "^1.5.1",
+    "p-limit": "^7.3.0",
     "radix-ui": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/app/blog-astro/src/lib/content/loader/__test__/content-ingestion.test.ts
+++ b/app/blog-astro/src/lib/content/loader/__test__/content-ingestion.test.ts
@@ -1,6 +1,6 @@
 import type { LoaderContext } from "astro/loaders";
 import { fs, vol } from "memfs";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import {
   afterAll,
@@ -91,6 +91,7 @@ describe("content ingestion", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     githubServer.resetHandlers();
   });
 
@@ -350,6 +351,103 @@ Body`,
     expect(requestedRefPath.endsWith("/git/ref/main/content")).toBe(true);
     expect(requestedContentRef).toBe("main/content");
     expect(authorization).toBe("Bearer secret");
+  });
+
+  it("bounds concurrent GitHub file acquisition", async () => {
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const remoteFiles = Array.from({ length: 12 }, (_, index) => ({
+      type: "file",
+      path: `posts/post-${index}.md`,
+    }));
+    githubServer.use(
+      http.get("https://api.github.com/repos/:owner/:repo/git/ref/*", () =>
+        HttpResponse.json({ object: { sha: "concurrency-sha" } }),
+      ),
+      http.get(
+        "https://api.github.com/repos/:owner/:repo/contents/*",
+        async ({ request }) => {
+          const requestedPath = new URL(request.url).pathname.split(
+            "/contents/",
+          )[1];
+          if (requestedPath === "posts") {
+            return HttpResponse.json(remoteFiles);
+          }
+
+          activeRequests += 1;
+          maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+          await delay(20);
+          activeRequests -= 1;
+          const slug = requestedPath!.split("/").at(-1)!.replace(".md", "");
+          return HttpResponse.json({
+            name: `${slug}.md`,
+            encoding: "base64",
+            content: Buffer.from(markdown(slug, slug, "Body")).toString(
+              "base64",
+            ),
+          });
+        },
+      ),
+    );
+    const { context, entries } = createContext();
+    const loader = markdownFileSetLoader({
+      source: "https://github.com/owner/repo/tree/main/posts",
+      githubToken: "secret",
+    });
+
+    await loader.load(context);
+
+    expect(entries.size).toBe(12);
+    expect(maxActiveRequests).toBeLessThanOrEqual(6);
+  });
+
+  it("retries a timed-out GitHub request with a fresh abort signal", async () => {
+    vi.useFakeTimers();
+    let fileRequests = 0;
+    githubServer.use(
+      http.get("https://api.github.com/repos/:owner/:repo/git/ref/*", () =>
+        HttpResponse.json({ object: { sha: "retry-sha" } }),
+      ),
+      http.get(
+        "https://api.github.com/repos/:owner/:repo/contents/*",
+        async ({ request }) => {
+          const requestedPath = new URL(request.url).pathname.split(
+            "/contents/",
+          )[1];
+          if (requestedPath === "posts") {
+            return HttpResponse.json([
+              { type: "file", path: "posts/resilient.md" },
+            ]);
+          }
+
+          fileRequests += 1;
+          if (fileRequests === 1) {
+            await delay(5_001);
+          }
+          return HttpResponse.json({
+            name: "resilient.md",
+            encoding: "base64",
+            content: Buffer.from(
+              markdown("resilient", "Resilient", "Body"),
+            ).toString("base64"),
+          });
+        },
+      ),
+    );
+    const { context, entries } = createContext();
+    const loader = markdownFileSetLoader({
+      source: "https://github.com/owner/repo/tree/main/posts",
+      githubToken: "secret",
+    });
+
+    const loadExpectation = expect(
+      loader.load(context),
+    ).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(7_000);
+    await loadExpectation;
+
+    expect(fileRequests).toBe(2);
+    expect([...entries.keys()]).toEqual(["resilient"]);
   });
 
   it("does not reacquire GitHub files when the ref SHA is unchanged", async () => {

--- a/app/blog-astro/src/lib/content/loader/content-ingestion.ts
+++ b/app/blog-astro/src/lib/content/loader/content-ingestion.ts
@@ -4,6 +4,7 @@ import { load } from "js-yaml";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ofetch } from "ofetch";
+import pLimit from "p-limit";
 
 type LoaderOptions = {
   source: string;
@@ -38,6 +39,7 @@ type SourceAcquirer<T> = {
 
 const SOURCE_REVISION_KEY = "sourceRevision";
 const LEGACY_SOURCE_REVISION_KEY = "lastSha";
+const GITHUB_FILE_FETCH_CONCURRENCY = 6;
 
 export function markdownFileSetLoader(options: LoaderOptions): Loader {
   const fileToId = new Map<string, string>();
@@ -289,13 +291,16 @@ async function fetchGithubFiles(
     throw new Error(`GitHub path ${location.path} is not a directory`);
   }
 
+  const limit = pLimit(GITHUB_FILE_FETCH_CONCURRENCY);
   const files = await Promise.all(
     contents
       .filter((entry) => entry.type === "file")
-      .map(async (entry) => ({
-        path: entry.path,
-        content: await fetchGithubFile(request, location, entry.path),
-      })),
+      .map((entry) =>
+        limit(async () => ({
+          path: entry.path,
+          content: await fetchGithubFile(request, location, entry.path),
+        })),
+      ),
   );
   return files;
 }
@@ -324,6 +329,10 @@ function githubRequest(token: string) {
     retry: 3,
     retryDelay: 500,
     timeout: 5000,
+    onRequest({ options }) {
+      // Let ofetch create a new timeout controller for every retry attempt.
+      options.signal = undefined;
+    },
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       ofetch:
         specifier: ^1.5.1
         version: 1.5.1
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       radix-ui:
         specifier: 'catalog:'
         version: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Summary

- bound concurrent GitHub content file acquisition to six requests
- let ofetch create a fresh timeout signal for every retry attempt
- add regression coverage for concurrency and timeout recovery

## Validation

- `CI=true turbo run check-types lint test` — 21/21 tasks passed
- `pnpm --filter blog-astro exec astro check` — 0 diagnostics
- real-content local frontend build — passed
- Vercel cold-path preview — Ready; content store cleared and 91 pages built

Preview: https://blog-a5kj3vdph-yy4382s-projects.vercel.app